### PR TITLE
Feature store mixin fetch

### DIFF
--- a/lib/components/MantraForm.vue
+++ b/lib/components/MantraForm.vue
@@ -19,12 +19,12 @@ export default {
     beforeRouteEnter(to, from, next) {
         const path = getPathFromObject(to);
 
-        try {
+        try {            
             const config = MantraForm._getConfig({ path });
             pushToRouteParams(to, { config });
             next();
         } catch(err) {
-            error(err.message);
+            error(err);
             next('*');
         }
     },
@@ -35,7 +35,7 @@ export default {
             return createElement('404', context.data, children);
         }
         
-        return createElement(config.component.name, { ...context.data, props: { config } }, children);
+        return createElement(config.component.name, { ...context.data, props: { config, role: 'ROOT' } }, children);
     }
 };
 </script>

--- a/lib/components/MantraForm.vue
+++ b/lib/components/MantraForm.vue
@@ -19,7 +19,7 @@ export default {
     beforeRouteEnter(to, from, next) {
         const path = getPathFromObject(to);
 
-        try {            
+        try {
             const config = MantraForm._getConfig({ path });
             pushToRouteParams(to, { config });
             next();

--- a/lib/core/MantraData.js
+++ b/lib/core/MantraData.js
@@ -29,7 +29,7 @@ export default class MantraData {
         this.name = '';
         this.schema = null;
         this.id = '';
-        this.action = '';
+        this.action = {};
         this.context = '';
         this.endpoint = '';
         this._path = path;
@@ -225,7 +225,7 @@ export default class MantraData {
      */
     _setId(id) {
         this.id = id;
-        this._trimPath(id);
+        this.updatePath(id);
     };
 
     /**
@@ -248,6 +248,13 @@ export default class MantraData {
      */
     setAction() {
         this.action = this._getAction();
+    };
+
+    /**
+     * Returns whether or not the class action needs to fetch data
+     */
+    get needFetch() {
+        return (this.action.needFetch !== false);
     };
 
     /**

--- a/lib/mixins/MantraForm.js
+++ b/lib/mixins/MantraForm.js
@@ -1,8 +1,9 @@
 import _baseMixin from './_base';
+import _store from './Store';
 
 const MIXIN = {
     $m_mixin: 'MantraForm',
-    mixins: [ _baseMixin ],
+    mixins: [ _baseMixin, _store ],
     methods: {},
 };
 

--- a/lib/mixins/Store.js
+++ b/lib/mixins/Store.js
@@ -1,0 +1,116 @@
+import has from 'lodash/has';
+import get from 'lodash/get';
+
+import { MantraPlugin } from './../MantraPlugin';
+import { error } from './../utils';
+
+const name = 'store';
+const prefix = `$fm_${name}`;
+
+const MIXIN = {
+    $fm_store: { name },
+    beforeCreate() {},
+    provide() {},
+    created() {
+        this.__setStates();
+        this.initState(this.config);
+    },
+    computed: {},
+    methods: {
+        async initState(data) {
+            const value = await this._getInitState(data);
+            const source = await this._getSource(data);
+            return this.setStore({ value, source }, data);
+        },
+        // STATE RELATED
+        _getInitState(data) {
+            if (this.isNewState(data)) {                
+                return this._initState(data);
+            }
+            return this._handleNonNewState(data);
+        },
+        async _initState(data) {
+            if (!data.needFetch) {
+                return {};
+            }
+            return this._getNewState(data);
+        },
+        _getNewState(data) {
+            const request = this.createRequest(data);
+            const { alias:name } = data; 
+            const requestObject = { name, request };
+            this.registerRequest(requestObject);
+            return this.getPendingRequest(data);
+        },
+        _handleNonNewState(data) {
+            if (this._getStateStatus(data) === 'PENDING') {
+                return this.getPendingRequest(data);
+            }
+            return this.getExistingState(data);
+        },
+        _getStateStatus(data) {
+            if (this.doesStateExists(data)) {
+                return 'EXISTING';
+            }
+            if (this.isRequestPending(data)) {
+                return 'PENDING';
+            }
+            return 'NEW';
+        },
+        getExistingState(data) {
+            return get(this.mantra.store, data.statePath);
+        },
+        // REQUEST
+        createRequest(data) {
+            const HttpClient = MantraPlugin.getHttpClient.call(this);
+            const { endpoint, alias } = data;
+
+            return new Promise((resolve, reject) => {
+                HttpClient.get(endpoint).then((response) => {
+                    resolve(response.data);
+                }).catch((e) => {
+                    reject(e);
+                    error(e);
+                }).finally(() => {                    
+                    this.deregisterRequest(alias);
+                });
+            });
+        },
+        registerRequest(requestObject) {
+            this.mantra.requests = [ ...this.mantra.requests, requestObject ];
+        },
+        deregisterRequest(alias) {
+            this.mantra.requests = this.mantra.requests.filter(request => request.name !== alias);
+        },
+        getPendingRequest(data) {
+            return this.mantra.requests.find(request => request.name === data.alias).request;
+        },
+        async _getSource(data) {},
+        setStore(state, data) {},
+        // BOOLEANS
+        isNewState(data) {
+            return (this._getStateStatus(data) === 'NEW');
+        },
+        doesStateExists(data) {
+            return has(this.mantra.store, data.statePath);
+        },
+        isRequestPending(data) {
+            const IS_REQUEST_EMPTY = (this.mantra.requests.length > 0);
+            return IS_REQUEST_EMPTY && (this.mantra.requests.findIndex(request => request.name === data.alias) !== -1);
+        },
+        // ROOT / CHILD STRATEGY
+        __setStates(){
+            if (!this.isRoot) return;
+            this.r_setStates();
+        },
+        r_setStates(){
+            this.mantra = {
+                ...this.mantra,
+                store: {},
+                requests: [],
+            }; 
+        },
+    },
+};
+
+export default MIXIN;

--- a/lib/mixins/_base.js
+++ b/lib/mixins/_base.js
@@ -9,8 +9,8 @@ const MIXIN = {
         role: {
             type: String,
             required: true,
-            validator: function(value) {
-                return ['ROOT', 'CHILD'].some(option => option === value);
+            validator(value) {
+                return ['ROOT', 'CHILD'].includes(value);
             }
         }
     },

--- a/lib/mixins/_base.js
+++ b/lib/mixins/_base.js
@@ -5,8 +5,25 @@ const MIXIN = {
         config: {
             type: [ MantraData ],
             required: true,
+        },
+        role: {
+            type: String,
+            required: true,
+            validator: function(value) {
+                return ['ROOT', 'CHILD'].some(option => option === value);
+            }
         }
-    }
+    },
+    data() {
+        return {
+            mantra: {},
+        };
+    },
+    computed: {
+        isRoot() {
+            return (this.role === 'ROOT');
+        },
+    },
 };
 
 export default MIXIN;

--- a/lib/mixins/store.js
+++ b/lib/mixins/store.js
@@ -1,3 +1,0 @@
-const MIXIN = {};
-
-export default MIXIN;

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,7 +938,6 @@
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
       "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -6700,8 +6699,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vue": "^2.6.11"
   },
   "dependencies": {
+    "@babel/runtime": "^7.9.2",
     "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
**Details**
- Extend `_base mixin` to support `role` prop and its computed `isRole` in order to add support for strategy pattern over this prop.
- Add @babel/runtime to dependencies to support async function declarations.
- Adjust the `id` property on a `MantraData` to be included in its `endpoint` property.
- Add `role` prop to be default `ROOT` at render() of the MantraForm Functional Component.
- Integrate '__' prefixed methods as indicator of Role base strategy method. Example with the __setStates().
- Integrate 'r_' prefixed methods as the `ROOT` strategy resolved version for a `__` prefixed method. Example with the r_setStates().
- Handle data fetch `memoization` for the `Store mixin`.
- Resolve `status` of `pending request` to avoid `duplicated` request.
- Dynamically resolve a `HttpClient` to fetch data from `external API`, based on the `MantraData endpoint` property.

